### PR TITLE
Add review week to schedule

### DIFF
--- a/elixir_in_action/README.md
+++ b/elixir_in_action/README.md
@@ -38,10 +38,11 @@ Mondays @ 7:00pm via Google Hangouts
 |  [7: Building a concurrent system]  | Nathan   | Feb 27 |
 |  [8: Fault-tolerance basics]        | Hugo     | Mar 06 |
 |  [9: Isolating error effects]       | Chris    | Mar 13 |
-| [10: Sharing state]                 | Lee      | Mar 20 |
-| [11: Working with components]       | Masa     | Mar 27 |
-| [12: Building a distributed system] | Michael  | Apr 03 |
-| [13: Running the system]            | Nathan   | Apr 10 |
+|  Review/Catch Up Week               | n/a      | Mar 20 |
+| [10: Sharing state]                 | Lee      | Mar 27 |
+| [11: Working with components]       | Masa     | Apr 03 |
+| [12: Building a distributed system] | Michael  | Apr 10 |
+| [13: Running the system]            | Nathan   | Apr 17 |
 
 [1: First steps]: 01_first_steps
 [2: Building blocks]: 02_building_blocks


### PR DESCRIPTION
As per our discussion a couple weeks back, last week was a review week.
This gave us a chance to play with the code exercises, re-read
challenging sections, and catch up on skipped work, and generally let
the material sink in.

This week, we're back to our normal schedule.